### PR TITLE
fix deriving channel

### DIFF
--- a/grass_analysis_W10_anna.ipynb
+++ b/grass_analysis_W10_anna.ipynb
@@ -210,11 +210,8 @@
    "outputs": [],
    "source": [
     "# derive main channel\n",
-    "gs.mapcalc(\"main_channel = if(stream_hack != 1, null(), 1)\")\n",
-    "gs.run_command(\"r.to.vect\", input=\"main_channel\", output=\"mc_vect\", type=\"line\")\n",
-    "# get rid of an artifact during vectorization (removes lines smaller than 1 m)\n",
-    "gs.run_command(\"v.edit\", map=\"mc_vect\", type=\"line\", tool=\"delete\", threshold=\"-1,0,-1\", query=\"length\")\n",
-    "gs.run_command(\"v.build.polylines\", input=\"mc_vect\", output=\"polylines\", cats=\"first\")"
+    "gs.run_command(\"v.extract\", input=\"stream_v\", where='\"hack\" = 1', output=\"main_channel\")\n",
+    "gs.run_command(\"v.build.polylines\", input=\"main_channel\", output=\"polylines\", cats=\"first\")"
    ]
   },
   {


### PR DESCRIPTION
This should fix deriving the channel, I should have thought about this earlier... It uses the vector streams derived by r.stream.order and extract lines with hack order 1.